### PR TITLE
chore: 发布 1.1.80，提交文档构建与忽略项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dist
 build
 pnpm-lock.yaml
 package-lock.json
+
+prompts
+graphify-out

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+npm run build:docs
+git add src/components/*/README.md README.md
 npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.79",
+  "version": "1.1.80",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",
@@ -11,7 +11,8 @@
     "test": "craco test --coverage",
     "eject": "react-scripts eject",
     "prettier": "prettier --config .prettierrc --write '{src/**/*}.{js,jsx,ts,tsx,json,css,scss}'",
-    "lint-staged": "npx lint-staged"
+    "lint-staged": "npx lint-staged",
+    "build:docs": "modules-dev-build-docs"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary
- 版本 `1.1.79` → `1.1.80`（重新发版，替换 CDN 上 1.1.79 生产包的 TDZ 异常）
- pre-commit 增加 `build:docs`，提交时同步组件 README
- `.gitignore` 增加 `prompts`、`graphify-out`

## Test plan
- [ ] CI Publish 完成后 CDN `components-admin@1.1.80` 可加载
- [ ] flowup 指向 1.1.80 后，管理端启动不再出现 `Cannot access ... before initialization`
- [ ] 本地 `npm start`（3016）仍正常


Made with [Cursor](https://cursor.com)