### PR TITLE
chore: 升级 @kne/modules-dev 至 ^2.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.80",
+  "version": "1.1.81",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",
@@ -65,7 +65,7 @@
     }
   },
   "devDependencies": {
-    "@kne/modules-dev": "^2.4.3",
+    "@kne/modules-dev": "^2.4.10",
     "@kne/react-fetch": "^1.5.7",
     "@kne/react-scripts": "^5.1.5",
     "@kne/remote-loader": "^1.2.3",


### PR DESCRIPTION
## Summary
- `@kne-components/components-admin` **1.1.80 → 1.1.81**
- `@kne/modules-dev` **^2.4.3 → ^2.4.10**（已发布；生产构建关闭 `concatenateModules`）
- 重发 CDN，修复远程包 `Cannot access ... before initialization`（本地 `craco start` 正常、CDN 异常）

依赖：[kne-union/modules-dev#132](https://github.com/kne-union/modules-dev/pull/132)

## Test plan
- [ ] CI Publish 完成后确认 CDN `1.1.81` 可加载
- [ ] 宿主 `craco start` 将 `components-admin` 升到 `1.1.81`，打开需 `Authenticate` 的页面，不再出现 TDZ
- [ ] `npm start` 开发态行为不变


Made with [Cursor](https://cursor.com)