### PR TITLE
fix: BizUnit 操作成功后从第一页 refresh 列表

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",

--- a/src/components/BizUnit/README.md
+++ b/src/components/BizUnit/README.md
@@ -592,6 +592,204 @@ render(<MapFilterNoListNextExample />);
 
 ```
 
+- 题目管理（卡片下拉加载后操作刷新）
+- 验收：卡片 forceCard 下拉到 currentPage=2 后点「添加数字人任务」，操作后第一次 list 须为 currentPage=1；之后继续下拉加载第 2 页是正常行为。顶部 Alert 区分「操作后刷新」与「下拉加载」。
+- _BizUnit(@components/BizUnit),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader),antd(antd)
+
+```jsx
+const { default: BizUnit } = _BizUnit;
+const { default: preset } = _mockPreset;
+const { createWithRemoteLoader } = remoteLoader;
+const { Alert, Typography, Button } = antd;
+
+const PAGE_SIZE = 6;
+const TOTAL = 36;
+
+const questionList = Array.from({ length: TOTAL }, (_, index) => ({
+  id: index + 1,
+  title: &#96;面试题目 ${index + 1}&#96;,
+  language: index % 2 === 0 ? 'zh-CN' : 'en-US',
+  createdAt: &#96;2026-08-${String((index % 28) + 1).padStart(2, '0')} 09:00:00&#96;
+}));
+
+const readRequestParams = payload => {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+  if (payload.params && typeof payload.params === 'object') {
+    return payload.params;
+  }
+  if (payload.data && typeof payload.data === 'object') {
+    return payload.data;
+  }
+  return payload;
+};
+
+const getItemExtra = (columns, item) => {
+  const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  return value?.children || null;
+};
+
+const renderQuestionCard = ({ dataSource = [], columns }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+    {dataSource.map(item => (
+      <div
+        key={item.id}
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 12,
+          padding: 12,
+          border: '1px solid #f0f0f0',
+          borderRadius: 8
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: 600 }}>{item.title}</div>
+          <div style={{ color: '#888', fontSize: 12 }}>
+            ID {item.id} · {item.language}
+          </div>
+        </div>
+        <div>{getItemExtra(columns, item)}</div>
+      </div>
+    ))}
+  </div>
+);
+
+const AddDigitalTaskDemo = ({ data, onSuccess, children, ...props }) => {
+  const { message } = antd;
+  return (
+    <Button
+      type="link"
+      {...props}
+      onClick={() => {
+        message.success(&#96;已为「${data.title}」添加数字人任务&#96;);
+        onSuccess && onSuccess();
+      }}
+    >
+      {children}
+    </Button>
+  );
+};
+
+/**
+ * 验收点：卡片模式下拉加载到第 2 页后，行内操作触发的第一次请求必须是 currentPage=1。
+ * 未修复时会带着 loadMore 留下的页码请求 currentPage=2。操作后继续下拉加载属于正常行为。
+ */
+const CardReloadAfterLoadMoreExample = createWithRemoteLoader({
+  modules: ['components-core:Global@PureGlobal', 'components-core:Layout']
+})(({ remoteModules }) => {
+  const [PureGlobal, Layout] = remoteModules;
+  const [requests, setRequests] = React.useState([]);
+  const pendingResetRef = React.useRef(false);
+  const scrollRef = React.useRef(null);
+
+  const getColumns = () => [
+    { name: 'id', title: 'ID', width: 80, renderType: 'id' },
+    { name: 'title', title: '题目', width: 240, renderType: 'main' },
+    { name: 'language', title: '语言', width: 100 },
+    { name: 'createdAt', title: '创建时间', width: 180, format: 'datetime' }
+  ];
+
+  const getActionList = ({ data, onSuccess, ...rest }) => [
+    {
+      ...rest,
+      data,
+      children: '添加数字人任务',
+      buttonComponent: AddDigitalTaskDemo,
+      onSuccess: () => {
+        pendingResetRef.current = true;
+        onSuccess && onSuccess();
+      }
+    }
+  ];
+
+  const apis = {
+    list: {
+      loader: payload => {
+        const params = readRequestParams(payload);
+        const currentPage = Number(params.currentPage) || 1;
+        const perPage = Number(params.perPage) || PAGE_SIZE;
+        const isReset = pendingResetRef.current;
+        if (isReset) {
+          pendingResetRef.current = false;
+        }
+        setRequests(prev => prev.concat({ currentPage, perPage, isReset, at: Date.now() }));
+        const start = (currentPage - 1) * perPage;
+        return Promise.resolve({
+          pageData: questionList.slice(start, start + perPage),
+          totalCount: questionList.length
+        });
+      }
+    }
+  };
+
+  const hasLoadedNextPage = requests.some(item => item.currentPage >= 2 && !item.isReset);
+  const lastReset = [...requests].reverse().find(item => item.isReset);
+  const passed = lastReset && lastReset.currentPage === 1;
+  const failed = lastReset && lastReset.currentPage >= 2;
+  const paramsText = requests.length
+    ? requests
+        .map((item, index) => {
+          const tag = item.isReset ? '  ← 操作后刷新' : item.currentPage > 1 ? '  ← 下拉加载' : '';
+          return &#96;#${index + 1} currentPage=${item.currentPage} perPage=${item.perPage}${tag}&#96;;
+        })
+        .join('\n')
+    : '（尚未发起列表请求）';
+
+  return (
+    <PureGlobal preset={{ ...preset, apis: { question: apis } }}>
+      <Layout navigation={{ isFixed: false }}>
+        <div style={{ padding: '0 0 12px' }}>
+          <Alert
+            type={passed ? 'success' : failed ? 'error' : 'info'}
+            showIcon
+            message={
+              passed
+                ? &#96;验收通过：操作后刷新回到 currentPage = ${lastReset.currentPage}；之后继续下拉加载是正常行为&#96;
+                : failed
+                  ? &#96;验收失败：操作后第一次请求 currentPage = ${lastReset.currentPage}（应为 1）&#96;
+                  : hasLoadedNextPage
+                    ? '已加载到第 2 页，请点任意题目的「添加数字人任务」'
+                    : '验收步骤：将卡片列表滚到底加载第 2 页 → 点「添加数字人任务」→ 操作后第一次请求须为 currentPage=1'
+            }
+            description={
+              <Typography.Paragraph style={{ marginBottom: 0 }} copyable={{ text: paramsText }}>
+                <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{paramsText}</pre>
+              </Typography.Paragraph>
+            }
+          />
+        </div>
+        <div ref={scrollRef} style={{ height: 420, overflow: 'auto' }}>
+          <BizUnit
+            isNext
+            name="question-card-reload-after-load-more"
+            page={{ title: '题目管理（卡片下拉加载后刷新）' }}
+            apis={apis}
+            allowKeywordSearch={false}
+            getColumns={getColumns}
+            getActionList={getActionList}
+            options={{
+              bizName: '题目',
+              tableProps: {
+                forceCard: true,
+                renderCard: renderQuestionCard,
+                getScrollContainer: () => scrollRef.current,
+                pagination: { paramsType: 'params', pageSize: PAGE_SIZE }
+              }
+            }}
+          />
+        </div>
+      </Layout>
+    </PureGlobal>
+  );
+});
+
+render(<CardReloadAfterLoadMoreExample />);
+
+```
+
 - 产品目录（表单弹窗配置）
 - 场景：商品管理。覆盖 options.formSize、formProps、formModalProps、createFormModalProps、editFormModalProps、saveData。
 - _BizUnit(@components/BizUnit),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader)

--- a/src/components/BizUnit/doc/card-reload-after-load-more-next.js
+++ b/src/components/BizUnit/doc/card-reload-after-load-more-next.js
@@ -1,0 +1,190 @@
+const { default: BizUnit } = _BizUnit;
+const { default: preset } = _mockPreset;
+const { createWithRemoteLoader } = remoteLoader;
+const { Alert, Typography, Button } = antd;
+
+const PAGE_SIZE = 6;
+const TOTAL = 36;
+
+const questionList = Array.from({ length: TOTAL }, (_, index) => ({
+  id: index + 1,
+  title: `面试题目 ${index + 1}`,
+  language: index % 2 === 0 ? 'zh-CN' : 'en-US',
+  createdAt: `2026-08-${String((index % 28) + 1).padStart(2, '0')} 09:00:00`
+}));
+
+const readRequestParams = payload => {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+  if (payload.params && typeof payload.params === 'object') {
+    return payload.params;
+  }
+  if (payload.data && typeof payload.data === 'object') {
+    return payload.data;
+  }
+  return payload;
+};
+
+const getItemExtra = (columns, item) => {
+  const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  return value?.children || null;
+};
+
+const renderQuestionCard = ({ dataSource = [], columns }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+    {dataSource.map(item => (
+      <div
+        key={item.id}
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 12,
+          padding: 12,
+          border: '1px solid #f0f0f0',
+          borderRadius: 8
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: 600 }}>{item.title}</div>
+          <div style={{ color: '#888', fontSize: 12 }}>
+            ID {item.id} · {item.language}
+          </div>
+        </div>
+        <div>{getItemExtra(columns, item)}</div>
+      </div>
+    ))}
+  </div>
+);
+
+const AddDigitalTaskDemo = ({ data, onSuccess, children, ...props }) => {
+  const { message } = antd;
+  return (
+    <Button
+      type="link"
+      {...props}
+      onClick={() => {
+        message.success(`已为「${data.title}」添加数字人任务`);
+        onSuccess && onSuccess();
+      }}
+    >
+      {children}
+    </Button>
+  );
+};
+
+/**
+ * 验收点：卡片模式下拉加载到第 2 页后，行内操作触发的第一次请求必须是 currentPage=1。
+ * 未修复时会带着 loadMore 留下的页码请求 currentPage=2。操作后继续下拉加载属于正常行为。
+ */
+const CardReloadAfterLoadMoreExample = createWithRemoteLoader({
+  modules: ['components-core:Global@PureGlobal', 'components-core:Layout']
+})(({ remoteModules }) => {
+  const [PureGlobal, Layout] = remoteModules;
+  const [requests, setRequests] = React.useState([]);
+  const pendingResetRef = React.useRef(false);
+  const scrollRef = React.useRef(null);
+
+  const getColumns = () => [
+    { name: 'id', title: 'ID', width: 80, renderType: 'id' },
+    { name: 'title', title: '题目', width: 240, renderType: 'main' },
+    { name: 'language', title: '语言', width: 100 },
+    { name: 'createdAt', title: '创建时间', width: 180, format: 'datetime' }
+  ];
+
+  const getActionList = ({ data, onSuccess, ...rest }) => [
+    {
+      ...rest,
+      data,
+      children: '添加数字人任务',
+      buttonComponent: AddDigitalTaskDemo,
+      onSuccess: () => {
+        pendingResetRef.current = true;
+        onSuccess && onSuccess();
+      }
+    }
+  ];
+
+  const apis = {
+    list: {
+      loader: payload => {
+        const params = readRequestParams(payload);
+        const currentPage = Number(params.currentPage) || 1;
+        const perPage = Number(params.perPage) || PAGE_SIZE;
+        const isReset = pendingResetRef.current;
+        if (isReset) {
+          pendingResetRef.current = false;
+        }
+        setRequests(prev => prev.concat({ currentPage, perPage, isReset, at: Date.now() }));
+        const start = (currentPage - 1) * perPage;
+        return Promise.resolve({
+          pageData: questionList.slice(start, start + perPage),
+          totalCount: questionList.length
+        });
+      }
+    }
+  };
+
+  const hasLoadedNextPage = requests.some(item => item.currentPage >= 2 && !item.isReset);
+  const lastReset = [...requests].reverse().find(item => item.isReset);
+  const passed = lastReset && lastReset.currentPage === 1;
+  const failed = lastReset && lastReset.currentPage >= 2;
+  const paramsText = requests.length
+    ? requests
+        .map((item, index) => {
+          const tag = item.isReset ? '  ← 操作后刷新' : item.currentPage > 1 ? '  ← 下拉加载' : '';
+          return `#${index + 1} currentPage=${item.currentPage} perPage=${item.perPage}${tag}`;
+        })
+        .join('\n')
+    : '（尚未发起列表请求）';
+
+  return (
+    <PureGlobal preset={{ ...preset, apis: { question: apis } }}>
+      <Layout navigation={{ isFixed: false }}>
+        <div style={{ padding: '0 0 12px' }}>
+          <Alert
+            type={passed ? 'success' : failed ? 'error' : 'info'}
+            showIcon
+            message={
+              passed
+                ? `验收通过：操作后刷新回到 currentPage = ${lastReset.currentPage}；之后继续下拉加载是正常行为`
+                : failed
+                  ? `验收失败：操作后第一次请求 currentPage = ${lastReset.currentPage}（应为 1）`
+                  : hasLoadedNextPage
+                    ? '已加载到第 2 页，请点任意题目的「添加数字人任务」'
+                    : '验收步骤：将卡片列表滚到底加载第 2 页 → 点「添加数字人任务」→ 操作后第一次请求须为 currentPage=1'
+            }
+            description={
+              <Typography.Paragraph style={{ marginBottom: 0 }} copyable={{ text: paramsText }}>
+                <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{paramsText}</pre>
+              </Typography.Paragraph>
+            }
+          />
+        </div>
+        <div ref={scrollRef} style={{ height: 420, overflow: 'auto' }}>
+          <BizUnit
+            isNext
+            name="question-card-reload-after-load-more"
+            page={{ title: '题目管理（卡片下拉加载后刷新）' }}
+            apis={apis}
+            allowKeywordSearch={false}
+            getColumns={getColumns}
+            getActionList={getActionList}
+            options={{
+              bizName: '题目',
+              tableProps: {
+                forceCard: true,
+                renderCard: renderQuestionCard,
+                getScrollContainer: () => scrollRef.current,
+                pagination: { paramsType: 'params', pageSize: PAGE_SIZE }
+              }
+            }}
+          />
+        </div>
+      </Layout>
+    </PureGlobal>
+  );
+});
+
+render(<CardReloadAfterLoadMoreExample />);

--- a/src/components/BizUnit/doc/example.json
+++ b/src/components/BizUnit/doc/example.json
@@ -35,6 +35,17 @@
       ]
     },
     {
+      "title": "题目管理（卡片下拉加载后操作刷新）",
+      "description": "验收：卡片 forceCard 下拉到 currentPage=2 后点「添加数字人任务」，操作后第一次 list 须为 currentPage=1；之后继续下拉加载第 2 页是正常行为。顶部 Alert 区分「操作后刷新」与「下拉加载」。",
+      "code": "./card-reload-after-load-more-next.js",
+      "scope": [
+        { "name": "_BizUnit", "packageName": "@components/BizUnit" },
+        { "name": "_mockPreset", "packageName": "@root/mockPreset" },
+        { "name": "remoteLoader", "packageName": "@kne/remote-loader" },
+        { "name": "antd", "packageName": "antd" }
+      ]
+    },
+    {
       "title": "产品目录（表单弹窗配置）",
       "description": "场景：商品管理。覆盖 options.formSize、formProps、formModalProps、createFormModalProps、editFormModalProps、saveData。",
       "code": "./form-options-next.js",

--- a/src/components/BizUnit/index.js
+++ b/src/components/BizUnit/index.js
@@ -178,7 +178,15 @@ const BizUnit = createWithRemoteLoader({
         : getFilterValue(filterValue);
 
       const reloadTable = () => {
-        ref.current?.reload();
+        const pagination = options.tableProps?.pagination || {};
+        const paramsType = pagination.paramsType || 'params';
+        const currentName = pagination.currentName || 'currentPage';
+        // reload 会保留 ScrollLoader，触底计数用尽后无法再下拉；refresh 卸掉子树以重置分页与加载器
+        ref.current?.refresh({
+          [paramsType]: {
+            [currentName]: 1
+          }
+        });
       };
 
       const toolbarExtra = (


### PR DESCRIPTION
## Summary
- 卡片列表下拉加载后，行内/新建操作会带着 `currentPage` 刷新；改为 `refresh({ params: { currentPage: 1 } })`，卸掉 ScrollLoader 并从第一页重拉。
- 增加「题目管理（卡片下拉加载后操作刷新）」示例用于验收。
- 版本：`1.1.81` → `1.1.82`。合并 master 后由 Publish workflow 发布 `@kne-components/components-admin`。

## Test plan
- [ ] 打开 BizUnit 示例「题目管理（卡片下拉加载后操作刷新）」
- [ ] 将卡片列表滚到底加载第 2 页
- [ ] 点「添加数字人任务」，第一次 list 须为 `currentPage=1`
- [ ] 操作后继续下拉仍能加载后续页


Made with [Cursor](https://cursor.com)