### PR TITLE
feat: BizUnit 行操作 ButtonGroup 默认 place=end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.82",
+  "version": "1.1.83",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",

--- a/src/components/BizUnit/Actions/index.js
+++ b/src/components/BizUnit/Actions/index.js
@@ -14,6 +14,8 @@ const Actions = createWithRemoteLoader({
       moreType,
       children,
       itemClassName,
+      className,
+      place = 'end',
       getActionList,
       getFormInner,
       data,
@@ -120,13 +122,15 @@ const Actions = createWithRemoteLoader({
 
       if (typeof children === 'function') {
         return children({
+          className,
           itemClassName,
           moreType,
+          place,
           list: actionList
         });
       }
 
-      return <ButtonGroup itemClassName={itemClassName} list={actionList} moreType={moreType} />;
+      return <ButtonGroup className={className} place={place} itemClassName={itemClassName} list={actionList} moreType={moreType} />;
     }
   )
 );

--- a/src/components/BizUnit/README.md
+++ b/src/components/BizUnit/README.md
@@ -34,13 +34,44 @@
 #### 示例代码
 
 - 角色管理（基础 CRUD）
-- 场景：角色权限管理。覆盖 isNext、apis（含函数形式）、getColumns（renderType/tag/datetime/description）、getFormInner（create/edit）、page、onMount、options 按钮文案与 removeMessage、关键字搜索。
+- 场景：角色权限管理。覆盖 isNext、apis（含函数形式）、getColumns（renderType/tag/datetime/description）、getFormInner（create/edit）、page、onMount、options 按钮文案与 removeMessage、关键字搜索、tableProps.renderMobile/renderCard。
 - _BizUnit(@components/BizUnit),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader),antd(antd)
 
 ```jsx
 const { default: BizUnit } = _BizUnit;
 const { default: preset } = _mockPreset;
 const { createWithRemoteLoader } = remoteLoader;
+
+const getItemExtra = (columns, item) => {
+  const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  return value?.children || null;
+};
+
+const renderRoleCard = ({ dataSource = [], columns, renderToolbar }) => (
+  <div>
+    {typeof renderToolbar === 'function' ? renderToolbar() : null}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {dataSource.map(item => (
+        <div
+          key={item.id}
+          style={{
+            border: '1px solid #eef0f3',
+            borderRadius: 12,
+            padding: 16,
+            background: '#fff'
+          }}
+        >
+          <div style={{ fontWeight: 600 }}>{item.name}</div>
+          <div style={{ color: '#888', fontSize: 12, marginTop: 4 }}>
+            {item.code} · {item.description}
+          </div>
+          <div style={{ marginTop: 12, paddingTop: 10, borderTop: '1px dashed #f0f0f0' }}>{getItemExtra(columns, item)}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
 
 const roleList = [
   {
@@ -149,7 +180,11 @@ const BaseNextExample = createWithRemoteLoader({
             createButtonProps: { children: '新建角色', type: 'primary' },
             editButtonProps: { children: '编辑' },
             removeButtonProps: { children: '删除' },
-            removeMessage: '删除后该角色下的用户将失去对应权限，确定继续？'
+            removeMessage: '删除后该角色下的用户将失去对应权限，确定继续？',
+            tableProps: {
+              renderMobile: renderRoleCard,
+              renderCard: renderRoleCard
+            }
           }}
         />
       </Layout>
@@ -1310,7 +1345,7 @@ render(<CustomActionsNextExample />);
 ```
 
 - 组织架构（Layout@TablePage 多页面）(全屏)
-- 场景：部门与分类管理。AppChildrenRouter + components-core:Layout 多子路由；BizUnit isNext 默认渲染 Layout@TablePage（page.menu 侧栏导航）；覆盖 filter、tableProps.batchActions/rowSelection。
+- 场景：部门与分类管理。AppChildrenRouter + components-core:Layout 多子路由；BizUnit isNext 默认渲染 Layout@TablePage（page.menu 侧栏导航）；覆盖 filter、tableProps.batchActions/rowSelection、renderMobile/renderCard。
 - _BizUnit(@components/BizUnit),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader),appChildrenRouter(@kne/app-children-router),reactRouterDom(react-router-dom),antd(antd)
 
 ```jsx
@@ -1383,6 +1418,37 @@ const statusMap = {
   open: { type: 'success', text: '启用' },
   closed: { type: 'default', text: '停用' }
 };
+
+const getItemExtra = (columns, item) => {
+  const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  return value?.children || null;
+};
+
+const renderOrgCard = ({ dataSource = [], columns, renderToolbar }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    {typeof renderToolbar === 'function' ? renderToolbar() : null}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {dataSource.map(item => (
+        <div
+          key={item.id}
+          style={{
+            border: '1px solid #eef0f3',
+            borderRadius: 12,
+            padding: 16,
+            background: '#fff'
+          }}
+        >
+          <div style={{ fontWeight: 600 }}>{item.name}</div>
+          <div style={{ color: '#888', fontSize: 12, marginTop: 4 }}>
+            {[item.code, item.parent, item.leader, item.description].filter(Boolean).join(' · ')}
+          </div>
+          <div style={{ marginTop: 12, paddingTop: 10, borderTop: '1px dashed #f0f0f0' }}>{getItemExtra(columns, item)}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
 
 const departmentApis = {
   list: { loader: () => Promise.resolve({ pageData: departmentList, totalCount: departmentList.length }) },
@@ -1509,6 +1575,8 @@ const LayoutNextExample = createWithRemoteLoader({
     keywordFilterLabel: '部门关键字',
     tableProps: {
       rowKey: 'id',
+      renderMobile: renderOrgCard,
+      renderCard: renderOrgCard,
       rowSelection: getDepartmentRowSelection(departmentList),
       selectedRows: departmentSelectedRows,
       pagination: { pageSize: 10, showSizeChanger: true, showQuickJumper: true },
@@ -1557,6 +1625,8 @@ const LayoutNextExample = createWithRemoteLoader({
     keywordFilterLabel: '分类关键字',
     tableProps: {
       rowKey: 'id',
+      renderMobile: renderOrgCard,
+      renderCard: renderOrgCard,
       rowSelection: getCategoryRowSelection(categoryList),
       selectedRows: categorySelectedRows,
       pagination: { pageSize: 10, showSizeChanger: true, showQuickJumper: true },
@@ -2995,6 +3065,8 @@ filter = {
 |---------------|---------------|----------|--------|
 | moreType      | 更多按钮类型        | String   | 'link' |
 | itemClassName | 按钮项 className | String   | -      |
+| className     | 传给 ButtonGroup 根节点 | String   | -      |
+| place         | 传给 ButtonGroup，行内/卡片操作靠右 | String   | 'end'  |
 | getActionList | 操作列表函数        | Function | -      |
 | getFormInner  | 表单内容函数        | Function | -      |
 | data          | 当前行数据         | Object   | -      |

--- a/src/components/BizUnit/doc/api.md
+++ b/src/components/BizUnit/doc/api.md
@@ -189,6 +189,8 @@ filter = {
 |---------------|---------------|----------|--------|
 | moreType      | 更多按钮类型        | String   | 'link' |
 | itemClassName | 按钮项 className | String   | -      |
+| className     | 传给 ButtonGroup 根节点 | String   | -      |
+| place         | 传给 ButtonGroup，行内/卡片操作靠右 | String   | 'end'  |
 | getActionList | 操作列表函数        | Function | -      |
 | getFormInner  | 表单内容函数        | Function | -      |
 | data          | 当前行数据         | Object   | -      |

--- a/src/components/BizUnit/doc/base-next.js
+++ b/src/components/BizUnit/doc/base-next.js
@@ -2,6 +2,37 @@ const { default: BizUnit } = _BizUnit;
 const { default: preset } = _mockPreset;
 const { createWithRemoteLoader } = remoteLoader;
 
+const getItemExtra = (columns, item) => {
+  const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  return value?.children || null;
+};
+
+const renderRoleCard = ({ dataSource = [], columns, renderToolbar }) => (
+  <div>
+    {typeof renderToolbar === 'function' ? renderToolbar() : null}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {dataSource.map(item => (
+        <div
+          key={item.id}
+          style={{
+            border: '1px solid #eef0f3',
+            borderRadius: 12,
+            padding: 16,
+            background: '#fff'
+          }}
+        >
+          <div style={{ fontWeight: 600 }}>{item.name}</div>
+          <div style={{ color: '#888', fontSize: 12, marginTop: 4 }}>
+            {item.code} · {item.description}
+          </div>
+          <div style={{ marginTop: 12, paddingTop: 10, borderTop: '1px dashed #f0f0f0' }}>{getItemExtra(columns, item)}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
 const roleList = [
   {
     id: 1,
@@ -109,7 +140,11 @@ const BaseNextExample = createWithRemoteLoader({
             createButtonProps: { children: '新建角色', type: 'primary' },
             editButtonProps: { children: '编辑' },
             removeButtonProps: { children: '删除' },
-            removeMessage: '删除后该角色下的用户将失去对应权限，确定继续？'
+            removeMessage: '删除后该角色下的用户将失去对应权限，确定继续？',
+            tableProps: {
+              renderMobile: renderRoleCard,
+              renderCard: renderRoleCard
+            }
           }}
         />
       </Layout>

--- a/src/components/BizUnit/doc/example.json
+++ b/src/components/BizUnit/doc/example.json
@@ -3,7 +3,7 @@
   "list": [
     {
       "title": "角色管理（基础 CRUD）",
-      "description": "场景：角色权限管理。覆盖 isNext、apis（含函数形式）、getColumns（renderType/tag/datetime/description）、getFormInner（create/edit）、page、onMount、options 按钮文案与 removeMessage、关键字搜索。",
+      "description": "场景：角色权限管理。覆盖 isNext、apis（含函数形式）、getColumns（renderType/tag/datetime/description）、getFormInner（create/edit）、page、onMount、options 按钮文案与 removeMessage、关键字搜索、tableProps.renderMobile/renderCard。",
       "code": "./base-next.js",
       "scope": [
         { "name": "_BizUnit", "packageName": "@components/BizUnit" },
@@ -90,7 +90,7 @@
     {
       "title": "组织架构（Layout@TablePage 多页面）",
       "isFull": true,
-      "description": "场景：部门与分类管理。AppChildrenRouter + components-core:Layout 多子路由；BizUnit isNext 默认渲染 Layout@TablePage（page.menu 侧栏导航）；覆盖 filter、tableProps.batchActions/rowSelection。",
+      "description": "场景：部门与分类管理。AppChildrenRouter + components-core:Layout 多子路由；BizUnit isNext 默认渲染 Layout@TablePage（page.menu 侧栏导航）；覆盖 filter、tableProps.batchActions/rowSelection、renderMobile/renderCard。",
       "code": "./layout-next.js",
       "scope": [
         { "name": "_BizUnit", "packageName": "@components/BizUnit" },

--- a/src/components/BizUnit/doc/layout-next.js
+++ b/src/components/BizUnit/doc/layout-next.js
@@ -68,6 +68,37 @@ const statusMap = {
   closed: { type: 'default', text: '停用' }
 };
 
+const getItemExtra = (columns, item) => {
+  const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  return value?.children || null;
+};
+
+const renderOrgCard = ({ dataSource = [], columns, renderToolbar }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    {typeof renderToolbar === 'function' ? renderToolbar() : null}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {dataSource.map(item => (
+        <div
+          key={item.id}
+          style={{
+            border: '1px solid #eef0f3',
+            borderRadius: 12,
+            padding: 16,
+            background: '#fff'
+          }}
+        >
+          <div style={{ fontWeight: 600 }}>{item.name}</div>
+          <div style={{ color: '#888', fontSize: 12, marginTop: 4 }}>
+            {[item.code, item.parent, item.leader, item.description].filter(Boolean).join(' · ')}
+          </div>
+          <div style={{ marginTop: 12, paddingTop: 10, borderTop: '1px dashed #f0f0f0' }}>{getItemExtra(columns, item)}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
 const departmentApis = {
   list: { loader: () => Promise.resolve({ pageData: departmentList, totalCount: departmentList.length }) },
   create: { loader: () => Promise.resolve({ code: 0 }) },
@@ -193,6 +224,8 @@ const LayoutNextExample = createWithRemoteLoader({
     keywordFilterLabel: '部门关键字',
     tableProps: {
       rowKey: 'id',
+      renderMobile: renderOrgCard,
+      renderCard: renderOrgCard,
       rowSelection: getDepartmentRowSelection(departmentList),
       selectedRows: departmentSelectedRows,
       pagination: { pageSize: 10, showSizeChanger: true, showQuickJumper: true },
@@ -241,6 +274,8 @@ const LayoutNextExample = createWithRemoteLoader({
     keywordFilterLabel: '分类关键字',
     tableProps: {
       rowKey: 'id',
+      renderMobile: renderOrgCard,
+      renderCard: renderOrgCard,
       rowSelection: getCategoryRowSelection(categoryList),
       selectedRows: categorySelectedRows,
       pagination: { pageSize: 10, showSizeChanger: true, showQuickJumper: true },

--- a/src/preset.js
+++ b/src/preset.js
@@ -57,7 +57,7 @@ export const globalInit = async () => {
     //url: 'http://localhost:3001',
     //tpl: '{{url}}',
     remote: 'components-core',
-    defaultVersion: '0.5.33'
+    defaultVersion: '0.5.38'
   };
   remoteLoaderPreset({
     remotes: {


### PR DESCRIPTION
## Summary
- BizUnit `Actions` 把 `className`、`place`（默认 `end`）传给 ButtonGroup，卡片/行内操作靠右
- 角色管理、组织架构示例增加 `renderMobile` / `renderCard`（不含 forceCard）
- 远程 `components-core` `0.5.33` → `0.5.38`，以使用 ButtonGroup `place`
- version `1.1.82` → `1.1.83`

## Test plan
- [ ] 组织架构示例切到卡片，底栏「编辑/删除」靠右
- [ ] 全选条与卡片列表有间距
- [ ] 表格行操作仍可用
- [ ] 角色管理示例可切换卡片视图


Made with [Cursor](https://cursor.com)