### PR TITLE
fix: BizUnit Actions 默认左对齐，卡片自行传 place

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.83",
+  "version": "1.1.84",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",

--- a/src/components/BizUnit/Actions/index.js
+++ b/src/components/BizUnit/Actions/index.js
@@ -15,7 +15,7 @@ const Actions = createWithRemoteLoader({
       children,
       itemClassName,
       className,
-      place = 'end',
+      place,
       getActionList,
       getFormInner,
       data,

--- a/src/components/BizUnit/README.md
+++ b/src/components/BizUnit/README.md
@@ -44,7 +44,7 @@ const { createWithRemoteLoader } = remoteLoader;
 
 const getItemExtra = (columns, item) => {
   const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
-  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item, { place: 'end' }) : null;
   return value?.children || null;
 };
 
@@ -662,7 +662,7 @@ const readRequestParams = payload => {
 
 const getItemExtra = (columns, item) => {
   const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
-  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item, { place: 'end' }) : null;
   return value?.children || null;
 };
 
@@ -1421,7 +1421,7 @@ const statusMap = {
 
 const getItemExtra = (columns, item) => {
   const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
-  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item, { place: 'end' }) : null;
   return value?.children || null;
 };
 
@@ -3066,7 +3066,7 @@ filter = {
 | moreType      | 更多按钮类型        | String   | 'link' |
 | itemClassName | 按钮项 className | String   | -      |
 | className     | 传给 ButtonGroup 根节点 | String   | -      |
-| place         | 传给 ButtonGroup，行内/卡片操作靠右 | String   | 'end'  |
+| place         | 传给 ButtonGroup。默认左对齐；卡片靠右时自行传 `end` | String   | `'start'` |
 | getActionList | 操作列表函数        | Function | -      |
 | getFormInner  | 表单内容函数        | Function | -      |
 | data          | 当前行数据         | Object   | -      |

--- a/src/components/BizUnit/buildOptionsColumn.js
+++ b/src/components/BizUnit/buildOptionsColumn.js
@@ -20,9 +20,20 @@ const buildOptionsColumn = ({ isNext, formatMessage, apis, options, getActionLis
       width: 180,
       min: 120,
       max: 240,
-      getValueOf: (item, ctx) => ({
-        children: <Actions {...actionsProps} data={item} fetchOptions={ctx?.context} />
-      })
+      getValueOf: (item, ctx) => {
+        const { context, place, className } = ctx || {};
+        return {
+          children: (
+            <Actions
+              {...actionsProps}
+              {...(place ? { place } : {})}
+              {...(className ? { className } : {})}
+              data={item}
+              fetchOptions={context}
+            />
+          )
+        };
+      }
     };
   }
 

--- a/src/components/BizUnit/doc/api.md
+++ b/src/components/BizUnit/doc/api.md
@@ -190,7 +190,7 @@ filter = {
 | moreType      | 更多按钮类型        | String   | 'link' |
 | itemClassName | 按钮项 className | String   | -      |
 | className     | 传给 ButtonGroup 根节点 | String   | -      |
-| place         | 传给 ButtonGroup，行内/卡片操作靠右 | String   | 'end'  |
+| place         | 传给 ButtonGroup。默认左对齐；卡片靠右时自行传 `end` | String   | `'start'` |
 | getActionList | 操作列表函数        | Function | -      |
 | getFormInner  | 表单内容函数        | Function | -      |
 | data          | 当前行数据         | Object   | -      |

--- a/src/components/BizUnit/doc/base-next.js
+++ b/src/components/BizUnit/doc/base-next.js
@@ -4,7 +4,7 @@ const { createWithRemoteLoader } = remoteLoader;
 
 const getItemExtra = (columns, item) => {
   const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
-  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item, { place: 'end' }) : null;
   return value?.children || null;
 };
 

--- a/src/components/BizUnit/doc/card-reload-after-load-more-next.js
+++ b/src/components/BizUnit/doc/card-reload-after-load-more-next.js
@@ -28,7 +28,7 @@ const readRequestParams = payload => {
 
 const getItemExtra = (columns, item) => {
   const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
-  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item, { place: 'end' }) : null;
   return value?.children || null;
 };
 

--- a/src/components/BizUnit/doc/layout-next.js
+++ b/src/components/BizUnit/doc/layout-next.js
@@ -70,7 +70,7 @@ const statusMap = {
 
 const getItemExtra = (columns, item) => {
   const column = (columns || []).find(col => col.name === 'options' || col.renderType === 'options');
-  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item) : null;
+  const value = typeof column?.getValueOf === 'function' ? column.getValueOf(item, { place: 'end' }) : null;
   return value?.children || null;
 };
 


### PR DESCRIPTION
## Summary
- `BizUnit.Actions` 不再默认 `place="end"`，TablePage 行操作恢复左对齐
- 卡片靠右时通过 `getValueOf(item, { place: 'end' })` 自行设置；示例已按此改
- 版本 `1.1.83` → `1.1.84`

## Test plan
- [ ] TablePage 行内操作默认靠左
- [ ] 卡片示例（base-next / layout-next）操作靠右
- [ ] 未传 `place` 时与 ButtonGroup 默认 `start` 一致


Made with [Cursor](https://cursor.com)