### PR TITLE
fix: Task 列表筛选走 mapFilterValue 嵌套 filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.84",
+  "version": "1.1.85",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",

--- a/src/components/Task/AllTask/index.js
+++ b/src/components/Task/AllTask/index.js
@@ -1,13 +1,13 @@
 import { createWithRemoteLoader } from '@kne/remote-loader';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { App } from 'antd';
-import { transform } from 'lodash';
 import withLocale from '../withLocale';
 import { useIntl } from '@kne/react-intl';
 
 import getColumns from '../getColumns';
 import Menu from '../Menu';
 import Actions from '../Actions';
+import { createTaskMapFilterValue } from '../filterUtils';
 
 const AllTask = createWithRemoteLoader({
   modules: [
@@ -33,7 +33,8 @@ const AllTask = createWithRemoteLoader({
       rowKey: 'id'
     });
 
-    const filterValue = getFilterValue(filter);
+    const mapFilterValue = useMemo(() => createTaskMapFilterValue({ sort }), [sort]);
+    const listParams = useMemo(() => mapFilterValue(filter, getFilterValue), [mapFilterValue, filter, getFilterValue]);
 
     const rowSelection = useMemo(
       () => ({
@@ -82,6 +83,7 @@ const AllTask = createWithRemoteLoader({
         filter={{
           value: filter,
           onChange: setFilter,
+          mapFilterValue: (value, getFv) => mapFilterValue(value, getFv || getFilterValue),
           list: [
             {
               type: InputFilterItem,
@@ -150,29 +152,7 @@ const AllTask = createWithRemoteLoader({
           ]
         }}
         {...Object.assign({}, apis.task.list, {
-          params: {
-            filter: Object.assign({}, filterValue, {
-              createdAt: filterValue.createdAt
-                ? {
-                    startTime: filterValue.createdAt.value[0],
-                    endTime: filterValue.createdAt.value[1]
-                  }
-                : null,
-              completedAt: filterValue.completedAt
-                ? {
-                    startTime: filterValue.completedAt.value[0],
-                    endTime: filterValue.completedAt.value[1]
-                  }
-                : null
-            }),
-            sort: transform(
-              sort,
-              (result, value) => {
-                result[value.name] = value.sort;
-              },
-              {}
-            )
-          },
+          params: listParams,
           dataFormat: data => {
             const list = (data.pageData || []).map(item =>
               Object.assign({}, item, {
@@ -206,7 +186,7 @@ const AllTask = createWithRemoteLoader({
                     data={item}
                     type="link"
                     onSuccess={() => {
-                      ref.current && ref.current.reload();
+                      ref.current?.reload?.({}, true);
                     }}
                   />
                 )

--- a/src/components/Task/MyTask/index.js
+++ b/src/components/Task/MyTask/index.js
@@ -1,12 +1,12 @@
 import { createWithRemoteLoader } from '@kne/remote-loader';
-import { useRef, useState } from 'react';
-import { transform } from 'lodash';
+import { useMemo, useRef, useState } from 'react';
 import withLocale from '../withLocale';
 import { useIntl } from '@kne/react-intl';
 
 import getColumns from '../getColumns';
 import Menu from '../Menu';
 import Actions from '../Actions';
+import { createTaskMapFilterValue } from '../filterUtils';
 
 const MyTask = createWithRemoteLoader({
   modules: ['components-core:Layout@TablePage', 'components-core:Global@usePreset', 'components-core:Filter', 'components-core:Enum']
@@ -14,7 +14,7 @@ const MyTask = createWithRemoteLoader({
   withLocale(({ remoteModules, baseUrl, getManualTaskAction, pageProps = {} }) => {
     const [TablePage, usePreset, Filter, Enum] = remoteModules;
     const { formatMessage } = useIntl();
-    const { apis, enums } = usePreset();
+    const { apis } = usePreset();
     const { getFilterValue, fields: filterFields } = Filter;
     const { InputFilterItem, SuperSelectFilterItem, TypeDateRangePickerFilterItem } = filterFields;
     const ref = useRef(null);
@@ -34,7 +34,11 @@ const MyTask = createWithRemoteLoader({
       selectedRows: []
     });
 
-    const filterValue = getFilterValue(filter);
+    const mapFilterValue = useMemo(
+      () => createTaskMapFilterValue({ sort, fixedFilter: { runnerType: 'manual' } }),
+      [sort]
+    );
+    const listParams = useMemo(() => mapFilterValue(filter, getFilterValue), [mapFilterValue, filter, getFilterValue]);
 
     const onSelectChange = (selectedRowKeys, selectedRows) => {
       setSelected({ selectedRowKeys, selectedRows });
@@ -50,6 +54,7 @@ const MyTask = createWithRemoteLoader({
         filter={{
           value: filter,
           onChange: setFilter,
+          mapFilterValue: (value, getFv) => mapFilterValue(value, getFv || getFilterValue),
           list: [
             {
               type: InputFilterItem,
@@ -100,30 +105,7 @@ const MyTask = createWithRemoteLoader({
           ]
         }}
         {...Object.assign({}, apis.task.list, {
-          params: {
-            filter: Object.assign({}, filterValue, {
-              createdAt: filterValue.createdAt
-                ? {
-                    startTime: filterValue.createdAt.value[0],
-                    endTime: filterValue.createdAt.value[1]
-                  }
-                : null,
-              completedAt: filterValue.completedAt
-                ? {
-                    startTime: filterValue.completedAt.value[0],
-                    endTime: filterValue.completedAt.value[1]
-                  }
-                : null,
-              runnerType: 'manual'
-            }),
-            sort: transform(
-              sort,
-              (result, value) => {
-                result[value.name] = value.sort;
-              },
-              {}
-            )
-          }
+          params: listParams
         })}
         ref={ref}
         pagination={{ paramsType: 'params' }}
@@ -145,7 +127,7 @@ const MyTask = createWithRemoteLoader({
                     data={item}
                     type="link"
                     onSuccess={() => {
-                      ref.current.reload();
+                      ref.current?.reload?.({}, true);
                     }}
                   />
                 )
@@ -166,7 +148,7 @@ const MyTask = createWithRemoteLoader({
         }}
         page={{
           menu: <Menu baseUrl={baseUrl} />,
-          ...pageProps,
+          ...pageProps
         }}
       />
     );

--- a/src/components/Task/README.md
+++ b/src/components/Task/README.md
@@ -117,6 +117,166 @@ render(<MyTaskExample />);
 
 ```
 
+- 筛选验收（isNext）
+- 全部任务 / 我的任务筛选验收：展示最近一次请求的 params.filter 与返回条数，可按预设用例验证状态、类型、执行方式、目标名称、日期范围筛选是否生效
+- _Task(@components/Task),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader),antd(antd)
+
+```jsx
+const { AllTask, MyTask } = _Task;
+const { default: mockPreset, loadFilteredTaskList } = _mockPreset;
+const { createWithRemoteLoader } = remoteLoader;
+const { useMemo, useState } = React;
+const { Alert, App, Button, Card, Flex, Segmented, Typography } = antd;
+
+const { Text, Paragraph } = Typography;
+
+const CompleteTaskAction = ({ data, onSuccess, ...props }) => {
+  const { message } = App.useApp();
+  return (
+    <Button
+      {...props}
+      onClick={() => {
+        message.success(&#96;已完成任务 ${data?.id}，正在按当前筛选刷新列表&#96;);
+        onSuccess && onSuccess();
+      }}
+    />
+  );
+};
+
+const acceptanceCases = [
+  { label: '状态 = 失败', expect: '仅任务 1003（批量邮件通知）' },
+  { label: '类型 = 数据导出', expect: '仅任务 1002（用户数据导出）' },
+  { label: '执行方式 = 手动', expect: '任务 1001、1004' },
+  { label: '目标名称包含「报告」', expect: '任务 1001、1006' },
+  { label: '创建日期 2024-03-08', expect: '任务 1001–1004' },
+  { label: '我的任务 → 完成 pending 任务', expect: '有成功提示，请求次数 +1，params.filter 仍含 runnerType: "manual"' }
+];
+
+const FilterNextExample = createWithRemoteLoader({
+  modules: ['components-core:Global@PureGlobal', 'components-core:Layout']
+})(({ remoteModules }) => {
+  const [PureGlobal, Layout] = remoteModules;
+  const [view, setView] = useState('all');
+  const [debug, setDebug] = useState({ params: null, result: null, requestSeq: 0 });
+
+  const preset = useMemo(() => {
+    return Object.assign({}, mockPreset, {
+      apis: Object.assign({}, mockPreset.apis, {
+        task: Object.assign({}, mockPreset.apis.task, {
+          list: {
+            loader: props => {
+              const params = props?.params || {};
+              setDebug(prev =>
+                Object.assign({}, prev, {
+                  params,
+                  requestedAt: new Date().toLocaleTimeString(),
+                  requestSeq: (prev.requestSeq || 0) + 1
+                })
+              );
+              return loadFilteredTaskList(props).then(result => {
+                setDebug(prev =>
+                  Object.assign({}, prev, {
+                    result: {
+                      totalCount: result.totalCount,
+                      ids: (result.pageData || []).map(item => item.id)
+                    }
+                  })
+                );
+                return result;
+              });
+            }
+          }
+        })
+      })
+    });
+  }, []);
+
+  return (
+    <PureGlobal preset={preset}>
+      <Layout navigation={{ isFixed: false }}>
+        <Flex vertical gap={16}>
+          <Alert
+            type="info"
+            showIcon
+            message="任务筛选验收（isNext + mapFilterValue）"
+            description={
+              <Flex vertical gap={8}>
+                <Paragraph style={{ marginBottom: 0 }}>
+                  下方表格切换筛选项后，列表条数与「最近一次请求」中的 <Text code>params.filter</Text> 应同步变化。
+                  「我的任务」默认筛 pending，pending 手动任务会显示完成；点击后会强制刷新列表（mock 数据不会改状态），请看成功提示和请求次数。
+                </Paragraph>
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {acceptanceCases.map(item => (
+                    <li key={item.label}>
+                      <Text strong>{item.label}</Text> → {item.expect}
+                    </li>
+                  ))}
+                </ul>
+              </Flex>
+            }
+          />
+
+          <Card size="small" title="最近一次请求（验收用）">
+            <Flex vertical gap={12}>
+              <Text type="secondary">
+                请求时间：{debug.requestedAt || '-'}　次数：{debug.requestSeq || 0}
+              </Text>
+              <div>
+                <Text strong>params.filter</Text>
+                <pre style={{ margin: '8px 0 0', padding: 12, background: '#f5f5f5', borderRadius: 6, fontSize: 12 }}>
+                  {JSON.stringify(debug.params?.filter || {}, null, 2)}
+                </pre>
+              </div>
+              <div>
+                <Text strong>返回结果</Text>
+                <pre style={{ margin: '8px 0 0', padding: 12, background: '#f5f5f5', borderRadius: 6, fontSize: 12 }}>
+                  {JSON.stringify(debug.result || {}, null, 2)}
+                </pre>
+              </div>
+            </Flex>
+          </Card>
+
+          <Segmented
+            value={view}
+            onChange={setView}
+            options={[
+              { label: '全部任务', value: 'all' },
+              { label: '我的任务（固定 manual）', value: 'my' }
+            ]}
+          />
+
+          {view === 'all' ? (
+            <AllTask
+              baseUrl="/Task"
+              pageProps={{
+                title: '全部任务 · 筛选验收',
+                menu: null,
+                menuOpen: false,
+                menuFixed: false
+              }}
+            />
+          ) : (
+            <MyTask
+              baseUrl="/Task"
+              getManualTaskAction={() => CompleteTaskAction}
+              pageProps={{
+                title: '我的任务 · 筛选验收',
+                menu: null,
+                menuOpen: false,
+                menuFixed: false
+              }}
+            />
+          )}
+        </Flex>
+      </Layout>
+    </PureGlobal>
+  );
+});
+
+render(<FilterNextExample />);
+
+```
+
 - 全部任务
 - 展示全部任务列表，包含手动执行和自动执行的任务，支持批量重试失败的任务
 - _Task(@components/Task),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader),reactRouterDom(react-router-dom)

--- a/src/components/Task/doc/example.json
+++ b/src/components/Task/doc/example.json
@@ -56,6 +56,29 @@
       ]
     },
     {
+      "title": "筛选验收（isNext）",
+      "description": "全部任务 / 我的任务筛选验收：展示最近一次请求的 params.filter 与返回条数，可按预设用例验证状态、类型、执行方式、目标名称、日期范围筛选是否生效",
+      "code": "./filter-next.js",
+      "scope": [
+        {
+          "name": "_Task",
+          "packageName": "@components/Task"
+        },
+        {
+          "name": "_mockPreset",
+          "packageName": "@root/mockPreset"
+        },
+        {
+          "name": "remoteLoader",
+          "packageName": "@kne/remote-loader"
+        },
+        {
+          "name": "antd",
+          "packageName": "antd"
+        }
+      ]
+    },
+    {
       "title": "全部任务",
       "description": "展示全部任务列表，包含手动执行和自动执行的任务，支持批量重试失败的任务",
       "code": "./all-task.js",

--- a/src/components/Task/doc/filter-next.js
+++ b/src/components/Task/doc/filter-next.js
@@ -1,0 +1,152 @@
+const { AllTask, MyTask } = _Task;
+const { default: mockPreset, loadFilteredTaskList } = _mockPreset;
+const { createWithRemoteLoader } = remoteLoader;
+const { useMemo, useState } = React;
+const { Alert, App, Button, Card, Flex, Segmented, Typography } = antd;
+
+const { Text, Paragraph } = Typography;
+
+const CompleteTaskAction = ({ data, onSuccess, ...props }) => {
+  const { message } = App.useApp();
+  return (
+    <Button
+      {...props}
+      onClick={() => {
+        message.success(`已完成任务 ${data?.id}，正在按当前筛选刷新列表`);
+        onSuccess && onSuccess();
+      }}
+    />
+  );
+};
+
+const acceptanceCases = [
+  { label: '状态 = 失败', expect: '仅任务 1003（批量邮件通知）' },
+  { label: '类型 = 数据导出', expect: '仅任务 1002（用户数据导出）' },
+  { label: '执行方式 = 手动', expect: '任务 1001、1004' },
+  { label: '目标名称包含「报告」', expect: '任务 1001、1006' },
+  { label: '创建日期 2024-03-08', expect: '任务 1001–1004' },
+  { label: '我的任务 → 完成 pending 任务', expect: '有成功提示，请求次数 +1，params.filter 仍含 runnerType: "manual"' }
+];
+
+const FilterNextExample = createWithRemoteLoader({
+  modules: ['components-core:Global@PureGlobal', 'components-core:Layout']
+})(({ remoteModules }) => {
+  const [PureGlobal, Layout] = remoteModules;
+  const [view, setView] = useState('all');
+  const [debug, setDebug] = useState({ params: null, result: null, requestSeq: 0 });
+
+  const preset = useMemo(() => {
+    return Object.assign({}, mockPreset, {
+      apis: Object.assign({}, mockPreset.apis, {
+        task: Object.assign({}, mockPreset.apis.task, {
+          list: {
+            loader: props => {
+              const params = props?.params || {};
+              setDebug(prev =>
+                Object.assign({}, prev, {
+                  params,
+                  requestedAt: new Date().toLocaleTimeString(),
+                  requestSeq: (prev.requestSeq || 0) + 1
+                })
+              );
+              return loadFilteredTaskList(props).then(result => {
+                setDebug(prev =>
+                  Object.assign({}, prev, {
+                    result: {
+                      totalCount: result.totalCount,
+                      ids: (result.pageData || []).map(item => item.id)
+                    }
+                  })
+                );
+                return result;
+              });
+            }
+          }
+        })
+      })
+    });
+  }, []);
+
+  return (
+    <PureGlobal preset={preset}>
+      <Layout navigation={{ isFixed: false }}>
+        <Flex vertical gap={16}>
+          <Alert
+            type="info"
+            showIcon
+            message="任务筛选验收（isNext + mapFilterValue）"
+            description={
+              <Flex vertical gap={8}>
+                <Paragraph style={{ marginBottom: 0 }}>
+                  下方表格切换筛选项后，列表条数与「最近一次请求」中的 <Text code>params.filter</Text> 应同步变化。
+                  「我的任务」默认筛 pending，pending 手动任务会显示完成；点击后会强制刷新列表（mock 数据不会改状态），请看成功提示和请求次数。
+                </Paragraph>
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {acceptanceCases.map(item => (
+                    <li key={item.label}>
+                      <Text strong>{item.label}</Text> → {item.expect}
+                    </li>
+                  ))}
+                </ul>
+              </Flex>
+            }
+          />
+
+          <Card size="small" title="最近一次请求（验收用）">
+            <Flex vertical gap={12}>
+              <Text type="secondary">
+                请求时间：{debug.requestedAt || '-'}　次数：{debug.requestSeq || 0}
+              </Text>
+              <div>
+                <Text strong>params.filter</Text>
+                <pre style={{ margin: '8px 0 0', padding: 12, background: '#f5f5f5', borderRadius: 6, fontSize: 12 }}>
+                  {JSON.stringify(debug.params?.filter || {}, null, 2)}
+                </pre>
+              </div>
+              <div>
+                <Text strong>返回结果</Text>
+                <pre style={{ margin: '8px 0 0', padding: 12, background: '#f5f5f5', borderRadius: 6, fontSize: 12 }}>
+                  {JSON.stringify(debug.result || {}, null, 2)}
+                </pre>
+              </div>
+            </Flex>
+          </Card>
+
+          <Segmented
+            value={view}
+            onChange={setView}
+            options={[
+              { label: '全部任务', value: 'all' },
+              { label: '我的任务（固定 manual）', value: 'my' }
+            ]}
+          />
+
+          {view === 'all' ? (
+            <AllTask
+              baseUrl="/Task"
+              pageProps={{
+                title: '全部任务 · 筛选验收',
+                menu: null,
+                menuOpen: false,
+                menuFixed: false
+              }}
+            />
+          ) : (
+            <MyTask
+              baseUrl="/Task"
+              getManualTaskAction={() => CompleteTaskAction}
+              pageProps={{
+                title: '我的任务 · 筛选验收',
+                menu: null,
+                menuOpen: false,
+                menuFixed: false
+              }}
+            />
+          )}
+        </Flex>
+      </Layout>
+    </PureGlobal>
+  );
+});
+
+render(<FilterNextExample />);

--- a/src/components/Task/filterUtils.js
+++ b/src/components/Task/filterUtils.js
@@ -1,0 +1,99 @@
+import { transform } from 'lodash';
+
+const FILTER_KEYS = ['id', 'targetId', 'type', 'status', 'runnerType', 'targetName', 'createdAt', 'completedAt'];
+
+const isDateRangeArray = value =>
+  Array.isArray(value) &&
+  value.length === 2 &&
+  (value[0] != null || value[1] != null) &&
+  !value.some(item => item && typeof item === 'object' && ('value' in item || 'id' in item));
+
+const toTimeString = value => {
+  if (value == null || value === '') {
+    return undefined;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value.toISOString === 'function') {
+    return value.toISOString();
+  }
+  return value;
+};
+
+export const unwrapFilterField = raw => {
+  if (raw == null || raw === '') {
+    return undefined;
+  }
+  if (isDateRangeArray(raw)) {
+    return raw;
+  }
+  if (Array.isArray(raw)) {
+    return unwrapFilterField(raw[0]);
+  }
+  if (typeof raw === 'object') {
+    if (isDateRangeArray(raw.value)) {
+      return raw.value;
+    }
+    if (raw.value != null && raw.value !== '' && typeof raw.value !== 'object') {
+      return raw.value;
+    }
+    if (raw.id != null && raw.id !== '') {
+      return raw.id;
+    }
+    return undefined;
+  }
+  return raw;
+};
+
+export const formatDateRangeFilter = rawValue => {
+  const range = unwrapFilterField(rawValue);
+  if (!isDateRangeArray(range)) {
+    return null;
+  }
+  if (!range[0] && !range[1]) {
+    return null;
+  }
+  return {
+    startTime: toTimeString(range[0]),
+    endTime: toTimeString(range[1])
+  };
+};
+
+export const createTaskMapFilterValue =
+  ({ sort, fixedFilter } = {}) =>
+  (filterValue, getFilterValue) => {
+    const items = Array.isArray(filterValue) ? filterValue : [];
+    const raw = typeof getFilterValue === 'function' ? getFilterValue(items) || {} : {};
+    const nextFilter = {};
+
+    ['id', 'targetId', 'type', 'status', 'runnerType', 'targetName'].forEach(key => {
+      const entry = items.find(item => item && item.name === key);
+      const scalar = unwrapFilterField(raw[key] != null ? raw[key] : entry && entry.value);
+      nextFilter[key] = scalar !== undefined && scalar !== '' ? scalar : null;
+    });
+
+    ['createdAt', 'completedAt'].forEach(key => {
+      const entry = items.find(item => item && item.name === key);
+      nextFilter[key] = formatDateRangeFilter(raw[key] != null ? raw[key] : entry && entry.value);
+    });
+
+    Object.assign(nextFilter, fixedFilter);
+
+    FILTER_KEYS.forEach(key => {
+      if (nextFilter[key] === undefined) {
+        nextFilter[key] = null;
+      }
+    });
+
+    return {
+      filter: nextFilter,
+      sort: transform(
+        sort,
+        (result, value) => {
+          result[value.name] = value.sort;
+        },
+        {}
+      )
+    };
+  };

--- a/src/mockPreset/index.js
+++ b/src/mockPreset/index.js
@@ -103,6 +103,62 @@ const loadFilteredTenantUserList = ({ params } = {}) =>
     return { pageData, totalCount };
   });
 
+const parseMockDateTime = value => {
+  if (!value) {
+    return NaN;
+  }
+  return new Date(String(value).replace(' ', 'T')).getTime();
+};
+
+const isWithinRange = (value, { startTime, endTime } = {}) => {
+  const time = parseMockDateTime(value);
+  if (Number.isNaN(time)) {
+    return false;
+  }
+  if (startTime && time < new Date(startTime).getTime()) {
+    return false;
+  }
+  if (endTime && time > new Date(endTime).getTime()) {
+    return false;
+  }
+  return true;
+};
+
+export const loadFilteredTaskList = ({ params } = {}) =>
+  import('./task-list.json').then(({ default: data }) => {
+    const filter = params?.filter || {};
+    let pageData = data.data?.pageData || [];
+
+    ['id', 'targetId', 'type', 'status', 'runnerType'].forEach(key => {
+      if (filter[key] != null && filter[key] !== '') {
+        pageData = pageData.filter(item => String(item[key]) === String(filter[key]));
+      }
+    });
+
+    if (filter.targetName) {
+      const keyword = String(filter.targetName).toLowerCase();
+      pageData = pageData.filter(item => String(item.input?.name || '').toLowerCase().includes(keyword));
+    }
+
+    if (filter.createdAt) {
+      pageData = pageData.filter(item => isWithinRange(item.createdAt, filter.createdAt));
+    }
+
+    if (filter.completedAt) {
+      pageData = pageData.filter(item => isWithinRange(item.completedAt, filter.completedAt));
+    }
+
+    const totalCount = pageData.length;
+    const perPage = Number(params?.perPage) || 20;
+    const currentPage = Number(params?.currentPage) || 1;
+    const start = (currentPage - 1) * perPage;
+
+    return {
+      pageData: pageData.slice(start, start + perPage),
+      totalCount
+    };
+  });
+
 const loadFilteredRoleList = ({ params } = {}) =>
   import('./tenant-data.json').then(({ default: data }) => {
     const filter = params?.filter || {};
@@ -123,9 +179,7 @@ const loadFilteredRoleList = ({ params } = {}) =>
 const apis = merge({}, getApis(), {
   task: {
     list: {
-      loader: () => {
-        return import('./task-list.json').then(({ default: data }) => data.data);
-      }
+      loader: loadFilteredTaskList
     },
     cancel: {
       loader: () => {


### PR DESCRIPTION
## Summary
- 修复 `AllTask` / `MyTask` 筛选不生效：`TablePage` isNext 后续筛选必须走 `mapFilterValue`，且始终返回嵌套 `{ filter }`，避免业务端 `components-core` 把字段打平后 `fastify-task` 读不到 `filter[status]` 等条件。
- 增加筛选验收示例与 mock 列表过滤。
- 版本：`1.1.84` → `1.1.85`（合入 master 后由 Publish workflow 发 npm）。

## Test plan
- [ ] 在 components-admin 本地 `npm start` 打开 Task「筛选验收（isNext）」示例，切换状态/类型后请求带 `filter[status]` 等嵌套参数。
- [ ] AllTask / MyTask 筛选后列表结果变化；MyTask 固定 `runnerType=manual`。
- [ ] 完成任务后列表按当前筛选刷新，不丢条件。
- [ ] 合入 master 后确认 Publish workflow 发布 `@kne-components/components-admin@1.1.85`。


Made with [Cursor](https://cursor.com)