### PR TITLE
feat: TenantAdmin 设置支持 appendSettingMenus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.85",
+  "version": "1.1.86",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",

--- a/src/components/TenantAdmin/README.md
+++ b/src/components/TenantAdmin/README.md
@@ -102,6 +102,7 @@ render(<TabDetailExample />);
 | showLanguageSetting | 是否在租户设置左菜单中显示「语言设置」；也可通过 `plugins.admin.tenant.showLanguageSetting` 配置 | boolean | `false` |
 | languageOptionsApi | 可选语言列表接口；不传时使用 `apis.intlAdmin.langType.list`；也可通过 `plugins.admin.tenant.languageOptionsApi` 配置 | object | `apis.intlAdmin.langType.list` |
 | showBuiltinLanguageOptions | 是否追加内置中文/英文选项；也可通过 `plugins.admin.tenant.showBuiltinLanguageOptions` 配置 | boolean | `false` |
+| appendSettingMenus | 追加「设置」左菜单项；也可通过 `plugins.admin.tenant.appendSettingMenus` 配置 | array | - |
 
 ### plugins.admin.tenant
 
@@ -111,3 +112,4 @@ render(<TabDetailExample />);
 | languageOptionsApi | 自定义语言列表 API（与 Fetch 兼容） | object | - |
 | showBuiltinLanguageOptions | 显示内置中文/英文 | boolean | `false` |
 | appendTabDetails | 追加租户详情 Tab | array | - |
+| appendSettingMenus | 追加「设置」左菜单项（`{ key, label, component, index? }`） | array | - |

--- a/src/components/TenantAdmin/TabDetail/Setting/index.js
+++ b/src/components/TenantAdmin/TabDetail/Setting/index.js
@@ -9,7 +9,7 @@ import CustomComponents from './CustomComponents';
 import Language from './Language';
 import style from './style.module.scss';
 
-const contentMap = {
+const builtinContentMap = {
   args: Args,
   customComponents: CustomComponents,
   language: Language
@@ -25,7 +25,8 @@ const Setting = createWithRemoteLoader({
       reload,
       showLanguageSetting: showLanguageSettingProp,
       languageOptionsApi: languageOptionsApiProp,
-      showBuiltinLanguageOptions: showBuiltinLanguageOptionsProp
+      showBuiltinLanguageOptions: showBuiltinLanguageOptionsProp,
+      appendSettingMenus: appendSettingMenusProp
     }) => {
       const [Menu, usePreset] = remoteModules;
       const { plugins } = usePreset();
@@ -43,8 +44,12 @@ const Setting = createWithRemoteLoader({
         showBuiltinLanguageOptionsProp !== void 0
           ? showBuiltinLanguageOptionsProp
           : !!get(plugins, 'admin.tenant.showBuiltinLanguageOptions', false);
+      const appendSettingMenus =
+        appendSettingMenusProp !== void 0
+          ? appendSettingMenusProp
+          : get(plugins, 'admin.tenant.appendSettingMenus', []) || [];
 
-      const menuItems = useMemo(() => {
+      const { menuItems, contentMap } = useMemo(() => {
         const items = [
           {
             key: 'args',
@@ -61,8 +66,24 @@ const Setting = createWithRemoteLoader({
             label: formatMessage({ id: 'LanguageSetting' })
           });
         }
-        return items;
-      }, [formatMessage, showLanguageSetting]);
+        const map = Object.assign({}, builtinContentMap);
+        (Array.isArray(appendSettingMenus) ? appendSettingMenus : []).forEach(item => {
+          if (!item || !item.key || !item.component) {
+            return;
+          }
+          const menuItem = {
+            key: item.key,
+            label: item.label || item.tab || item.key
+          };
+          if (Number.isInteger(item.index) && item.index >= 0) {
+            items.splice(item.index, 0, menuItem);
+          } else {
+            items.push(menuItem);
+          }
+          map[item.key] = item.component;
+        });
+        return { menuItems: items, contentMap: map };
+      }, [formatMessage, showLanguageSetting, appendSettingMenus]);
 
       const [activeKey, setActiveKey] = useState('args');
       const resolvedActiveKey = menuItems.some(item => item.key === activeKey) ? activeKey : 'args';

--- a/src/components/TenantAdmin/doc/api.md
+++ b/src/components/TenantAdmin/doc/api.md
@@ -3,6 +3,7 @@
 | showLanguageSetting | 是否在租户设置左菜单中显示「语言设置」；也可通过 `plugins.admin.tenant.showLanguageSetting` 配置 | boolean | `false` |
 | languageOptionsApi | 可选语言列表接口；不传时使用 `apis.intlAdmin.langType.list`；也可通过 `plugins.admin.tenant.languageOptionsApi` 配置 | object | `apis.intlAdmin.langType.list` |
 | showBuiltinLanguageOptions | 是否追加内置中文/英文选项；也可通过 `plugins.admin.tenant.showBuiltinLanguageOptions` 配置 | boolean | `false` |
+| appendSettingMenus | 追加「设置」左菜单项；也可通过 `plugins.admin.tenant.appendSettingMenus` 配置 | array | - |
 
 ### plugins.admin.tenant
 
@@ -12,3 +13,4 @@
 | languageOptionsApi | 自定义语言列表 API（与 Fetch 兼容） | object | - |
 | showBuiltinLanguageOptions | 显示内置中文/英文 | boolean | `false` |
 | appendTabDetails | 追加租户详情 Tab | array | - |
+| appendSettingMenus | 追加「设置」左菜单项（`{ key, label, component, index? }`） | array | - |


### PR DESCRIPTION
## Summary
- 新增 `plugins.admin.tenant.appendSettingMenus`（及同名 props），可在租户详情「设置」左菜单追加 `{ key, label, component, index? }`
- 文档同步更新；版本 `1.1.85` → `1.1.86`

## Test plan
- [ ] modules-dev / 业务仓指向本地 components-admin
- [ ] 配置 `appendSettingMenus` 后，租户详情 → 设置 左菜单出现自定义项并可渲染对应组件
- [ ] 不影响原有环境变量 / 自定义组件 / 语言设置菜单

Made with [Cursor](https://cursor.com)