### PR TITLE
fix: BizUnit Actions 将 className 同步到每个操作按钮

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-admin",
-  "version": "1.1.86",
+  "version": "1.1.87",
   "description": "用于实现一个后台管理系统的必要组件",
   "scripts": {
     "init": "husky",

--- a/src/components/BizUnit/Actions/index.js
+++ b/src/components/BizUnit/Actions/index.js
@@ -48,8 +48,12 @@ const Actions = createWithRemoteLoader({
         options
       );
 
+      // className 须同时落到每个按钮上：isNext options 会 cloneElement 传入 options-btn，
+      // 样式选择器是 .options-column .options-btn.ant-btn；只挂 ButtonGroup 容器无效。
+      // ButtonGroup 仍保留 className（卡片 place/布局用）。对齐 UserList/Actions。
       const props = {
         ...otherProps,
+        ...(className ? { className } : {}),
         fetchOptions,
         data,
         apis,


### PR DESCRIPTION
## Summary
- isNext `options` 会把 `options-btn` 经 `cloneElement` 传给 Actions；原先只挂在 ButtonGroup 容器上，按钮选不中样式
- 将 `className` 同步摊到每个操作按钮（对齐 UserList/Actions），容器上仍保留以支持卡片 place/布局
- version: 1.1.86 → 1.1.87

## Test plan
- [ ] 本地 `npm start`（3016），下游指向 localhost 后打开 BizUnit isNext 列表（如员工档案/岗位）
- [ ] 对比 `/tenant/setting/user` 与 BizUnit 列表行操作：padding / hover 底色一致
- [ ] 卡片模式若有 `place=end` 的操作区，仍靠右正常

Made with [Cursor](https://cursor.com)